### PR TITLE
Prevent duplicate prize winner

### DIFF
--- a/default.cshtml
+++ b/default.cshtml
@@ -89,6 +89,7 @@
         var ul = $('#people');
         spinBtn = $('#spin');
         var iterations = 2;
+        var candidates = [];
 
         function spin() {
             $('#people').removeClass("cover");
@@ -96,7 +97,17 @@
 
             var li = $('#people li');
             var count = li.length / iterations;
-            var newPos = -(li.first().outerHeight(true) * (Math.floor(Math.random() * count) + count * (iterations - 1))) - 5;
+
+            if (candidates.length === 0) {
+                for (var i = 0; i < count; i++) {
+                    var thisPos = -(li.first().outerHeight(true) * (i + count * (iterations - 1))) - 5;
+                    candidates.push(thisPos)
+                }
+            }
+
+            var randomIndex = Math.floor(Math.random() * candidates.length);
+            var newPos = candidates.splice(randomIndex, 1)[0];
+            
             li.first().animate({ marginTop: newPos }, 3000, 'easeOutCubic', function () {
                 spinBtn.attr('disabled', false).text('Spin Again!');
             });


### PR DESCRIPTION
Spinning is done by scrolling to a random position, e.g. `-13455` or `-10845`. We can end up with the random number generating the same "position" multiple times (I don't know why they were so prevalent last year). 

Since we know the list of people ahead of time, we can build a list of the possible positions and choose from them, removing as we go to ensure that nobody comes up twice.

- Does not persist across browser reloads (easy to do if that's what we want).

Fixes https://github.com/dddwa/ddd-backend/issues/72